### PR TITLE
Add dependabot configuration to automate dependencies update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,5 +11,5 @@ updates:
       interval: "monthly"
     labels:
       - "enhancement"
-     reviewers:
+    reviewers:
       - "baryonyx5"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"
+    labels:
+      - "enhancement"
+     reviewers:
+      - "baryonyx5"


### PR DESCRIPTION
This click plugin looks good but because it's using some security dependencies, it's important to keep them updated. It could be easily done using dependabot.

This PR adds the configuration file.