### PR TITLE
Handle default value for username parameter

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,5 +11,5 @@ updates:
       interval: "monthly"
     labels:
       - "enhancement"
-     reviewers:
+    reviewers:
       - "baryonyx5"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"
+    labels:
+      - "enhancement"
+     reviewers:
+      - "baryonyx5"


### PR DESCRIPTION
The purpose of this PR is to take into account the default value possibly defined for `username`.

# Example

Consider the below code (click_keyring_sample.py):

```python
import click
from click_keyring import keyring_option


@click.option("-u", "--username", default="Dummy Tester")
@keyring_option(
    "-p",
    "--password",
    prefix="testing",
)
@click.command()
def authenticated_cmd(username, password):
    """
    Example of click_keyring using defaults.

    The password will be saved to keyring with service name
    matching the click command name (in this case "authenticated_cmd").

    This can be overridden by setting `prefix` and/or `keyring_option`
     on the decorator.
    """
    click.echo()
    click.echo("** Command Params. User: {}, Password: {}".format(username, password))


if __name__ == "__main__":
    authenticated_cmd()
```

## Actual behavior

Using it:

```bash
> python click_keyring_sample.py -p "myRobustPassword"
Error: option 'username' must be provided before the password'
```

## New behavior

Using it:
```bash
> python click_keyring_sample.py -p "myRobustPassword"
** Command Params. User: Dummy Tester, Password: myRobustPassword
```

And:

```bash
> keyring get testing "Dummy Tester"
myRobustPassword
```
